### PR TITLE
Clarify STFT return values

### DIFF
--- a/musicviz/src/musicviz/utils/gpu_context.py
+++ b/musicviz/src/musicviz/utils/gpu_context.py
@@ -133,7 +133,7 @@ class GPUContext:
             hop_length: Hop length
             
         Returns:
-            np.ndarray: STFT magnitude
+            np.ndarray: STFT power spectrum
         """
         try:
             # If PyTorch is available, use torchaudio for GPU acceleration
@@ -173,7 +173,7 @@ class GPUContext:
             hop_length: Hop length
             
         Returns:
-            np.ndarray: STFT magnitude
+            np.ndarray: STFT power spectrum
         """
         # Import librosa only when needed (it's slow to import)
         try:


### PR DESCRIPTION
## Summary
- update STFT method docstring to indicate the function returns the power spectrum
- keep wording consistent for the CPU fallback

## Testing
- `python3 musicviz/run_tests.py --unit` *(fails: No module named pytest)*